### PR TITLE
Improve block collapse UI and bump version

### DIFF
--- a/app.js
+++ b/app.js
@@ -2289,7 +2289,19 @@ function toggleBlockCollapsed(index) {
   }
 
   block.collapsed = !block.collapsed;
-  renderProgram();
+
+  const node = programList.querySelector(`[data-index="${index}"]`);
+  if (node) {
+    node.dataset.collapsed = block.collapsed ? "true" : "false";
+    const toggle = node.querySelector(".collapse-toggle");
+    if (toggle) {
+      toggle.textContent = block.collapsed ? "\u25B8" : "\u25BE";
+      toggle.setAttribute("aria-label", block.collapsed ? t("expand") : t("collapse"));
+      toggle.setAttribute("title", block.collapsed ? t("expand") : t("collapse"));
+    }
+  } else {
+    renderProgram();
+  }
 }
 
 function collapseAllBlocks() {
@@ -4714,7 +4726,7 @@ function renderBlockPreview(index) {
 
   node.querySelector(".block-category").textContent = getBlockModeCaption(block);
   const descText = getBlockDescription(block);
-  node.querySelector(".block-description-label").textContent = descText ? t("blockDescriptionLabel") : "";
+  node.querySelector(".block-description-label").textContent = "";
   node.querySelector(".block-description").textContent = descText;
 }
 
@@ -4791,6 +4803,12 @@ function getCollapsedOperandText(block) {
   if (block.isIncBinMacro) {
     const size = (block.incBinBytes || []).length;
     if (block.incBinFileName) return `"${block.incBinFileName}" (${size} bytes)`;
+    return currentLanguage === "en" ? "no file" : "nincs fajl";
+  }
+
+  if (block.isSidMacro) {
+    const size = (block.sidBytes || []).length;
+    if (block.sidFileName) return `"${block.sidFileName}"${size ? ` (${size} bytes)` : ""}`;
     return currentLanguage === "en" ? "no file" : "nincs fajl";
   }
 
@@ -4887,7 +4905,7 @@ function renderProgram() {
       node.querySelector(".collapsed-operand").textContent = getCollapsedOperandText(block);
       node.querySelector(".block-category").textContent = getBlockModeCaption(block);
       const blockDescText = getBlockDescription(block);
-      node.querySelector(".block-description-label").textContent = blockDescText ? t("blockDescriptionLabel") : "";
+      node.querySelector(".block-description-label").textContent = "";
       node.querySelector(".block-description").textContent = blockDescText;
 
       const mode = addressingModes[block.addressingMode];
@@ -5374,11 +5392,6 @@ function renderProgram() {
       const blockModeSelect = node.querySelector(".block-mode");
       if (blockModeSelect) {
         blockModeSelect.addEventListener("change", (event) => updateProgramBlock(index, "addressingMode", event.target.value));
-      }
-
-      if (block.collapsed) {
-        blockControls.hidden = true;
-        node.querySelector(".block-description").hidden = true;
       }
 
       const moveUpButton = node.querySelector(".move-up");

--- a/index.html
+++ b/index.html
@@ -267,14 +267,18 @@
             </div>
             <button class="collapse-toggle" type="button" aria-label="Osszecsukas" title="Osszecsukas">&#9662;</button>
           </div>
-          <div class="block-controls">
-            <label class="inline-field">
-            <span>Operandus</span>
-            <input class="block-operand" type="text">
-          </label>
-        </div>
-        <span class="block-description-label"></span>
-        <p class="block-description"></p>
+          <div class="block-body">
+            <div class="block-body-inner">
+              <div class="block-controls">
+                <label class="inline-field">
+                <span>Operandus</span>
+                <input class="block-operand" type="text">
+              </label>
+            </div>
+            <span class="block-description-label"></span>
+            <p class="block-description"></p>
+            </div>
+          </div>
       </div>
       <div class="block-actions">
         <button class="move-up" type="button" aria-label="Fel" title="Fel">&#8593;</button>
@@ -308,7 +312,7 @@
       </svg>
     </div>
     <h2 class="about-title">C64 Visual Assembler</h2>
-    <p class="about-version" id="about-version">v1.2.5</p>
+    <p class="about-version" id="about-version">v1.2.6</p>
     <p class="about-desc">A visual block-based 6502 assembler for the Commodore 64.<br>Build programs by dragging and dropping instruction blocks.</p>
     <p class="about-author">&#169; 2026 Zsolt Tarczali</p>
     <button id="about-close" class="primary" type="button">Close</button>
@@ -318,8 +322,11 @@
 <dialog id="whats-new-dialog" class="whats-new-dialog">
   <div class="whats-new-card">
     <h2 class="whats-new-title">What's New</h2>
-    <p class="whats-new-version">v1.2.5</p>
+    <p class="whats-new-version">v1.2.6</p>
     <ul class="whats-new-list">
+      <li>
+        <strong>UI improvements</strong> — block collapse/expand is now animated with a smooth slide. Buttons are more compact and consistent across the interface. The version number is now visible in dark mode on the splash screen.
+      </li>
       <li>
         <strong>Mnemonic search</strong> — type in the palette search box to instantly filter instructions, macros, and categories by name or description. Results update as you type.
       </li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c64-visual-assembler",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Commodore 64 visual assembler desktop app built with Electron.",
   "author": "Zsolt Tarczali",
   "main": "main.js",

--- a/style.css
+++ b/style.css
@@ -550,12 +550,12 @@ body[data-theme="dark"] .primary {
 }
 
 .panel-heading-actions button {
-  min-height: 34px;
-  min-width: 34px;
-  width: 34px;
-  height: 34px;
+  min-height: 22px;
+  min-width: 22px;
+  width: 22px;
+  height: 22px;
   padding: 0;
-  font-size: 0.85rem;
+  font-size: 0.7rem;
   justify-content: center;
   align-items: center;
 }
@@ -1113,9 +1113,9 @@ button:focus-visible,
 }
 
 .collapse-toggle {
-  min-width: calc(24px * var(--block-scale));
-  width: calc(24px * var(--block-scale));
-  height: calc(24px * var(--block-scale));
+  min-width: calc(22px * var(--block-scale));
+  width: calc(22px * var(--block-scale));
+  height: calc(22px * var(--block-scale));
   min-height: unset;
   padding: 0;
   border-radius: 6px;
@@ -1130,6 +1130,18 @@ button:focus-visible,
 .inline-field span {
   font-size: calc(0.7rem * var(--block-scale));
   color: var(--muted);
+}
+
+.block-body {
+  display: grid;
+  grid-template-rows: 1fr;
+  overflow: hidden;
+  transition: grid-template-rows 220ms ease;
+}
+
+.block-body-inner {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .block-controls {
@@ -1322,9 +1334,9 @@ button:focus-visible,
 }
 
 .block-actions button {
-  min-width: calc(28px * var(--block-scale));
-  width: calc(28px * var(--block-scale));
-  height: calc(28px * var(--block-scale));
+  min-width: calc(22px * var(--block-scale));
+  width: calc(22px * var(--block-scale));
+  height: calc(22px * var(--block-scale));
   min-height: unset;
   aspect-ratio: 1;
   flex-shrink: 0;
@@ -1333,7 +1345,7 @@ button:focus-visible,
   background: var(--control-bg);
   border: 1px solid var(--panel-border);
   color: var(--text);
-  font-size: calc(0.8rem * var(--block-scale));
+  font-size: calc(0.72rem * var(--block-scale));
   line-height: 1;
   display: flex;
   align-items: center;
@@ -1403,11 +1415,14 @@ button:focus-visible,
 .asm-block[data-collapsed="true"] .block-topline {
   margin-bottom: 0;
   overflow: hidden;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .asm-block[data-collapsed="true"] .block-main {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  justify-content: center;
   min-width: 0;
   min-height: calc(28px * var(--block-scale));
 }
@@ -1430,9 +1445,10 @@ button:focus-visible,
   overflow: hidden;
 }
 
-.asm-block[data-collapsed="true"] .block-controls,
-.asm-block[data-collapsed="true"] .block-description-label,
-.asm-block[data-collapsed="true"] .block-description,
+.asm-block[data-collapsed="true"] .block-body {
+  grid-template-rows: 0fr;
+}
+
 .asm-block[data-collapsed="true"] .block-actions {
   display: none;
 }
@@ -1452,9 +1468,9 @@ button:focus-visible,
 }
 
 .asm-block[data-collapsed="true"] .collapse-toggle {
-  width: calc(28px * var(--block-scale));
-  min-width: calc(28px * var(--block-scale));
-  height: calc(28px * var(--block-scale));
+  width: calc(22px * var(--block-scale));
+  min-width: calc(22px * var(--block-scale));
+  height: calc(22px * var(--block-scale));
 }
 
 .asm-output {
@@ -2246,7 +2262,7 @@ body[data-theme="dark"] .emulator-actions .link-button.primary {
 .splash-version {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 0.8rem;
-  color: #2e1f7a;
+  color: var(--muted);
   margin: 0 0 2rem 0;
 }
 


### PR DESCRIPTION
Optimize and polish block collapse behavior and UI. Update toggleBlockCollapsed to update the single block node in-place (avoid full re-render) and ensure the collapse toggle text/labels update. Introduce .block-body and .block-body-inner wrappers and CSS transitions (grid-template-rows) to animate collapsing, adjust collapsed rules to hide body and actions via grid, and make compact button sizing and font tweaks for a tighter UI. Add collapsed operand formatting for SID macros (show filename and byte count). Update HTML structure to wrap block controls in the new block-body, bump app version to 1.2.6 in index.html and package.json, and add a brief whats-new note. Small text/style fixes (splash version color, button sizes).