### PR TITLE
Add Knowledge Base; fix zoom and ASM

### DIFF
--- a/app.js
+++ b/app.js
@@ -246,6 +246,9 @@ const aboutDialog = document.getElementById("about-dialog");
 const aboutCloseButton = document.getElementById("about-close");
 const whatsNewDialog = document.getElementById("whats-new-dialog");
 const whatsNewCloseButton = document.getElementById("whats-new-close");
+const knowledgeBaseButton = document.getElementById("knowledge-base-btn");
+const knowledgeBaseDialog = document.getElementById("knowledge-base-dialog");
+const knowledgeBaseCloseButton = document.getElementById("knowledge-base-close");
 const exitAppButton = document.getElementById("exit-app");
 
 let program = [];
@@ -994,6 +997,16 @@ function initPalette() {
     whatsNewDialog?.showModal();
   });
   whatsNewCloseButton?.addEventListener("click", () => whatsNewDialog?.close());
+  knowledgeBaseButton?.addEventListener("click", () => knowledgeBaseDialog?.showModal());
+  knowledgeBaseCloseButton?.addEventListener("click", () => knowledgeBaseDialog?.close());
+  knowledgeBaseDialog?.addEventListener("click", (e) => { if (e.target === knowledgeBaseDialog) knowledgeBaseDialog.close(); });
+  knowledgeBaseDialog?.querySelectorAll(".knowledge-base-link").forEach((link) => {
+    link.addEventListener("click", (e) => {
+      e.preventDefault();
+      const url = link.dataset.url;
+      if (url) window.electronAPI.openExternal(url);
+    });
+  });
   exitAppButton?.addEventListener("click", () => window.electronAPI.quitApp());
   setupOperandDropdown();
   sampleSelect?.addEventListener("change", saveUiSettings);
@@ -5913,17 +5926,19 @@ function renderAsmOutput() {
 
   // Build block → line-number index for ASM selection (2 header lines: "*= ..." + empty)
   asmBlockRanges = {};
+  let textLineNum = 2; // skip header "*= ..." (line 0) + empty (line 1)
   codeLines.forEach((codeLine, i) => {
     const block = layout.lines[i].block;
     const key = block._fromInclude || (block._fromMacro ? (block._invokeBlockId || null) : block.id);
+    const linesInEntry = codeLine.split("\n").length;
     if (key) {
-      const lineNum = i + 2; // offset of 2 header lines
       if (!asmBlockRanges[key]) {
-        asmBlockRanges[key] = { firstLine: lineNum, lastLine: lineNum };
+        asmBlockRanges[key] = { firstLine: textLineNum, lastLine: textLineNum + linesInEntry - 1 };
       } else {
-        asmBlockRanges[key].lastLine = lineNum;
+        asmBlockRanges[key].lastLine = textLineNum + linesInEntry - 1;
       }
     }
+    textLineNum += linesInEntry;
   });
 
   let asmText = [

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
                 <h3 class="control-menu-label control-menu-label--section">Info</h3>
                 <button id="about-btn" class="secondary" type="button">About</button>
                 <button id="whats-new-btn" class="secondary" type="button">What's New</button>
+                <button id="knowledge-base-btn" class="secondary" type="button">Knowledge Base</button>
                 <button id="check-update-btn" class="secondary" type="button">Check for Update</button>
               </section>
             </div>
@@ -323,7 +324,7 @@
       </svg>
     </div>
     <h2 class="about-title">C64 Visual Assembler</h2>
-    <p class="about-version" id="about-version">v1.2.7</p>
+    <p class="about-version" id="about-version">v1.2.8</p>
     <p class="about-desc">A visual block-based 6502 assembler for the Commodore 64.<br>Build programs by dragging and dropping instruction blocks.</p>
     <p class="about-author">&#169; 2026 Zsolt Tarczali</p>
     <button id="about-close" class="primary" type="button">Close</button>
@@ -333,8 +334,14 @@
 <dialog id="whats-new-dialog" class="whats-new-dialog">
   <div class="whats-new-card">
     <h2 class="whats-new-title">What's New</h2>
-    <p class="whats-new-version">v1.2.7</p>
+    <p class="whats-new-version">v1.2.8</p>
     <ul class="whats-new-list">
+      <li>
+        <strong>Zoom fix</strong> — block UI elements such as the Addressing mode selector, Format (HEX/DEC) toggle, INCBIN/INCLUDE file row, and SID metadata now correctly scale with the zoom level.
+      </li>
+      <li>
+        <strong>ASM selection highlight fix</strong> — the highlight in the ASM view no longer shifts when multi-line macros (<code>LOOP</code>, <code>NEXT</code>, <code>PUSH</code>, <code>PULL</code>) are present in the program. Previously, each multi-line macro caused all subsequent highlights to be offset by the number of extra lines it generated.
+      </li>
       <li>
         <strong>Label picker</strong> — operand fields on branch and jump instructions (<code>BNE</code>, <code>JMP</code>, <code>JSR</code>, etc.) now show a custom dropdown listing all labels defined in the current program. Click to insert — no more typing label names by hand.
       </li>
@@ -355,6 +362,40 @@
       </li>
     </ul>
     <button id="whats-new-close" class="primary" type="button">OK</button>
+  </div>
+</dialog>
+
+<dialog id="knowledge-base-dialog" class="knowledge-base-dialog">
+  <div class="knowledge-base-card">
+    <h2 class="knowledge-base-title">Knowledge Base</h2>
+    <p class="knowledge-base-subtitle">6502 &amp; C64 reference links</p>
+    <ul class="knowledge-base-list">
+      <li>
+        <a class="knowledge-base-link" href="#" data-url="http://www.6502.org/tutorials/6502opcodes.html">
+          <span class="knowledge-base-link-title">6502 Opcodes Reference</span>
+          <span class="knowledge-base-link-url">6502.org</span>
+        </a>
+      </li>
+      <li>
+        <a class="knowledge-base-link" href="#" data-url="https://sta.c64.org/cbm64krnfunc.html">
+          <span class="knowledge-base-link-title">C64 KERNAL Functions</span>
+          <span class="knowledge-base-link-url">sta.c64.org</span>
+        </a>
+      </li>
+      <li>
+        <a class="knowledge-base-link" href="#" data-url="https://sta.c64.org/cbm64mem.html">
+          <span class="knowledge-base-link-title">C64 Memory Map</span>
+          <span class="knowledge-base-link-url">sta.c64.org</span>
+        </a>
+      </li>
+      <li>
+        <a class="knowledge-base-link" href="#" data-url="https://sta.c64.org/cbm64col.html">
+          <span class="knowledge-base-link-title">C64 Color Codes</span>
+          <span class="knowledge-base-link-url">sta.c64.org</span>
+        </a>
+      </li>
+    </ul>
+    <button id="knowledge-base-close" class="primary" type="button">Close</button>
   </div>
 </dialog>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c64-visual-assembler",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Commodore 64 visual assembler desktop app built with Electron.",
   "author": "Zsolt Tarczali",
   "main": "main.js",

--- a/style.css
+++ b/style.css
@@ -1168,8 +1168,13 @@ button:focus-visible,
 .mini-field {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: calc(3px * var(--block-scale));
   margin-top: calc(4px * var(--block-scale));
+}
+
+.mini-field > span {
+  font-size: calc(0.7rem * var(--block-scale));
+  color: var(--muted);
 }
 
 .mini-field[hidden] {
@@ -1247,17 +1252,17 @@ button:focus-visible,
 .incbin-file-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: calc(6px * var(--block-scale));
   min-width: 0;
 }
 
 .sid-meta {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  margin-top: 6px;
-  padding: 6px 8px;
-  border-radius: 8px;
+  gap: calc(2px * var(--block-scale));
+  margin-top: calc(6px * var(--block-scale));
+  padding: calc(6px * var(--block-scale)) calc(8px * var(--block-scale));
+  border-radius: calc(8px * var(--block-scale));
   background: color-mix(in srgb, var(--panel-strong) 80%, var(--block-tone) 20%);
   font-size: calc(0.68rem * var(--block-scale));
   color: var(--muted);
@@ -1274,7 +1279,7 @@ button:focus-visible,
 
 .incbin-filename {
   flex: 1;
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--block-scale));
   color: var(--muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1314,9 +1319,9 @@ button:focus-visible,
 
 .incbin-browse-btn {
   flex-shrink: 0;
-  font-size: 0.65rem;
-  padding: 2px 6px;
-  border-radius: 4px;
+  font-size: calc(0.65rem * var(--block-scale));
+  padding: calc(2px * var(--block-scale)) calc(6px * var(--block-scale));
+  border-radius: calc(4px * var(--block-scale));
   background: var(--surface-soft);
   color: var(--text);
   border: 1px solid var(--border);
@@ -1332,9 +1337,9 @@ button:focus-visible,
 
 .include-browse-btn,
 .include-reload-btn {
-  font-size: 0.72rem;
-  padding: 2px 8px;
-  border-radius: 4px;
+  font-size: calc(0.72rem * var(--block-scale));
+  padding: calc(2px * var(--block-scale)) calc(8px * var(--block-scale));
+  border-radius: calc(4px * var(--block-scale));
   border: 1px solid var(--accent);
   background: var(--btn-bg, #444);
   color: var(--text);
@@ -1350,16 +1355,16 @@ button:focus-visible,
 .include-file-input {
   flex: 1;
   min-width: 0;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--block-scale));
   cursor: default;
 }
 
 .mini-toggle {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 3px;
-  padding: 2px;
-  border-radius: 8px;
+  gap: calc(3px * var(--block-scale));
+  padding: calc(2px * var(--block-scale));
+  border-radius: calc(8px * var(--block-scale));
   background: var(--surface-soft);
   width: fit-content;
 }
@@ -1378,12 +1383,12 @@ button:focus-visible,
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 24px;
-  min-width: 42px;
-  padding: 0 6px;
-  border-radius: 6px;
+  min-height: calc(24px * var(--block-scale));
+  min-width: calc(42px * var(--block-scale));
+  padding: 0 calc(6px * var(--block-scale));
+  border-radius: calc(6px * var(--block-scale));
   color: var(--muted);
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--block-scale));
   font-weight: 700;
   letter-spacing: 0.03em;
   transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
@@ -2253,6 +2258,85 @@ body[data-theme="dark"] .emulator-actions .link-button.primary {
 }
 
 #whats-new-close {
+  min-width: 120px;
+  align-self: flex-end;
+}
+
+/* ── Knowledge Base Dialog ───────────────────────────────────────── */
+.knowledge-base-dialog {
+  border: none;
+  border-radius: 20px;
+  padding: 0;
+  background: var(--panel);
+  max-width: 420px;
+  width: 92vw;
+}
+
+.knowledge-base-dialog::backdrop {
+  background: color-mix(in srgb, black 55%, transparent);
+  backdrop-filter: blur(4px);
+}
+
+.knowledge-base-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 32px 32px 28px;
+}
+
+.knowledge-base-title {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.knowledge-base-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.knowledge-base-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.knowledge-base-link {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: var(--surface-soft);
+  border: 1px solid var(--panel-border);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.knowledge-base-link:hover {
+  background: color-mix(in srgb, var(--secondary) 10%, var(--surface-soft));
+  border-color: var(--secondary);
+}
+
+.knowledge-base-link-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.knowledge-base-link-url {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--secondary);
+}
+
+#knowledge-base-close {
   min-width: 120px;
   align-self: flex-end;
 }


### PR DESCRIPTION
Add a Knowledge Base dialog and toolbar button with styles and handlers to open external reference links (index.html, style.css, app.js). Wire up dialog open/close and link clicks via electronAPI.openExternal. Bump app version to v1.2.8 and update the What's New text. Fix ASM selection highlight by correctly computing textLineNum and per-entry line counts so multi-line macros no longer offset subsequent highlights. Make various small UI elements scale with the --block-scale CSS variable to address zoom-related layout issues.