### PR TITLE
Migrate to Tauri 2 and bump to v1.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # C64 Visual Assembler
 
-An Electron-based desktop application for visually composing Commodore 64 6502 assembly programs using drag-and-drop blocks. Arrange mnemonics, macros, and labels in a program list and see the generated ASM and monitor output update in real time. Optionally run the program directly in VICE.
+A Tauri 2-based desktop application for visually composing Commodore 64 6502 assembly programs using drag-and-drop blocks. Arrange mnemonics, macros, and labels in a program list and see the generated ASM and monitor output update in real time. Optionally run the program directly in VICE.
 
-**Current version: v1.3.7**
+**Current version: v1.3.8**
+
+---
+
+## What's New
+
+### v1.3.8
+- Migrated from Electron to [Tauri 2](https://tauri.app/) — smaller binary, lower memory usage, no bundled Chromium
 
 ---
 
@@ -56,22 +63,20 @@ An Electron-based desktop application for visually composing Commodore 64 6502 a
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (v18+)
+- [Rust](https://rustup.rs/) (stable)
 - [VICE emulator](https://vice-emu.sourceforge.io/) (optional, for Run button)
 
 ### Install & run
 
 ```bash
 npm install
-npm start
+npm run dev
 ```
 
-### Build Windows installer
+### Build installer
 
 ```bash
-npm run dist              # produces NSIS installer (x64 + arm64) in dist/
-npm run dist:win:x64      # x64 only
-npm run dist:win:arm64    # arm64 only
-npm run dist:dir          # produces unpacked directory build in dist/
+npm run build             # produces NSIS installer (Windows) or .dmg (macOS) in src-tauri/target/
 ```
 
 ---
@@ -80,15 +85,18 @@ npm run dist:dir          # produces unpacked directory build in dist/
 
 ```
 VisualAssembler/
-├── index.html        # Single-page UI (all panels, templates)
-├── style.css         # Full stylesheet — CSS custom properties for theming
-├── app.js            # All renderer logic (~6 200 lines)
-├── main.js           # Electron main process (window, file dialogs, VICE IPC)
-├── preload.js        # contextBridge — exposes safe IPC API to renderer
-├── package.json      # electron + electron-builder config
-├── samples/          # Example .c64asm project files + binary assets
-└── build/
-    └── commodore64.ico
+├── www/
+│   ├── index.html        # Single-page UI (all panels, templates)
+│   ├── style.css         # Full stylesheet — CSS custom properties for theming
+│   ├── app.js            # All renderer logic (~6 200 lines)
+│   └── tauri-bridge.js   # Maps window.electronAPI calls to Tauri invoke commands
+├── src-tauri/
+│   ├── src/lib.rs        # Tauri backend — file dialogs, VICE launch, IPC commands
+│   ├── tauri.conf.json   # App config — window, bundle, icons
+│   ├── capabilities/     # Tauri permission system
+│   └── icons/            # App icons (all sizes)
+├── package.json          # Scripts + Tauri CLI dev dependency
+└── samples/              # Example .c64asm project files + binary assets
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "c64-visual-assembler",
-  "version": "1.3.7",
-  "description": "Commodore 64 visual assembler desktop app built with Tauri.",
+  "version": "1.3.8",
+  "description": "Commodore 64 visual assembler desktop app.",
   "author": "Zsolt Tarczali",
   "scripts": {
     "dev": "concurrently -k -n SERVE,TAURI \"npx serve -l 1430 ./www\" \"tauri dev\"",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "c64_visual_assembler_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "C64 Visual Assembler",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "identifier": "hu.zstarczali.c64visualassembler",
   "build": {
     "frontendDist": "../www",

--- a/www/index.html
+++ b/www/index.html
@@ -385,7 +385,12 @@
   <dialog id="whats-new-dialog" class="whats-new-dialog">
     <div class="whats-new-card">
       <h2 class="whats-new-title">What's New</h2>
-      <p class="whats-new-version">v1.3.7</p>
+      <p class="whats-new-version">v1.3.8</p>
+      <ul class="whats-new-list">
+        <li>
+          <strong>Migrated from Electron to Tauri 2</strong> — smaller binary, lower memory usage, no bundled Chromium
+        </li>
+      </ul>
       <ul class="whats-new-list">
         <li>
           <strong>CRT retro mode</strong> — full-screen CRT filter overlay: scanlines, phosphor vignette,

--- a/www/style.css
+++ b/www/style.css
@@ -2523,14 +2523,8 @@ body.crt-mode .app-layout {
 /* ── Splash Screen ────────────────────────────────────────────────── */
 .splash-screen {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   background: linear-gradient(135deg, var(--bg) 0%, var(--bg-accent) 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 10000;
   opacity: 1;
   transition: opacity 0.5s ease-out;
@@ -2542,6 +2536,10 @@ body.crt-mode .app-layout {
 }
 
 .splash-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   text-align: center;
   padding: 2rem;
 }


### PR DESCRIPTION
Migrate the project from Electron to Tauri 2 and update related metadata and docs. Bump package and tauri versions to v1.3.8, adjust package.json description, and update README with Tauri migration notes, new dev/build instructions, and revised project layout. Update src-tauri/Cargo.toml to remove the "staticlib" crate-type. Update www/index.html to show the v1.3.8 changelog entry and tweak the UI whats-new content. Replace absolute splash positioning in www/style.css with the inset shorthand for simpler layout.