### PR TITLE
Use popover-based tour card instead of dialog

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -15441,7 +15441,7 @@ function _runTutorialStepAction(actionId) {
       const _tc = document.getElementById("tour-card");
       if (_ov?.matches(":popover-open")) { _ov.hidePopover(); _ov.showPopover(); }
       if (_sp?.matches(":popover-open")) { _sp.hidePopover(); _sp.showPopover(); }
-      if (_tc?.open) { _tc.close(); _tc.showModal(); }
+      if (_tc?.matches(":popover-open")) { _tc.hidePopover(); _tc.showPopover(); }
       break;
     }
     case "close-settings-dialog":
@@ -15688,7 +15688,7 @@ function _tourStart(steps, lessonId, interactive = false) {
   if (!overlay?.matches(":popover-open")) overlay?.showPopover();
   spotlight.style.visibility = "hidden"; // start invisible, position per step
   if (!spotlight?.matches(":popover-open")) spotlight?.showPopover();
-  if (!card?.open) card?.showModal();
+  if (!card?.matches(":popover-open")) card?.showPopover();
   _tourShowStep(0);
 }
 
@@ -15924,7 +15924,7 @@ function _tourEnd() {
   if (overlay) overlay.style.pointerEvents = "all";
   if (overlay?.matches(":popover-open")) overlay.hidePopover();
   if (spotlight?.matches(":popover-open")) spotlight.hidePopover();
-  if (card?.open) card.close();
+  if (card?.matches(":popover-open")) card.hidePopover();
   if (_tourLessonId) _tutMarkDone(_tourLessonId);
 }
 

--- a/www/index.html
+++ b/www/index.html
@@ -797,7 +797,7 @@
   <!-- Tour overlay elements (popover=manual so they live in the top-layer above any showModal dialog) -->
   <div id="tour-overlay" popover="manual" aria-hidden="true"></div>
   <div id="tour-spotlight" popover="manual" aria-hidden="true"></div>
-  <dialog id="tour-card" class="tour-card" aria-labelledby="tour-card-title">
+  <div id="tour-card" class="tour-card" popover="manual" role="dialog" aria-labelledby="tour-card-title">
     <div class="tour-card-header">
       <span id="tour-step-label" class="tour-step-label">1 / 8</span>
       <button id="tour-skip" class="tour-skip-btn" type="button">× Skip</button>
@@ -808,7 +808,7 @@
       <button id="tour-prev" class="secondary tour-prev-btn" type="button">← Prev</button>
       <button id="tour-next" class="primary tour-next-btn" type="button">Next →</button>
     </div>
-  </dialog>
+  </div>
 
   <script src="tauri-bridge.js"></script>
   <script src="i18n.js?v=1.7.3"></script>

--- a/www/style.css
+++ b/www/style.css
@@ -5214,6 +5214,11 @@ body.crt-mode #crt-overlay::after {
   transition: left 300ms ease, top 300ms ease;
 }
 
+.tour-card::backdrop {
+  pointer-events: none;
+  background: transparent;
+}
+
 .tour-card-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Replace the tour card dialog with a popover-backed element and update JS/CSS to use the popover API. index.html: swap <dialog id="tour-card"> for a <div id="tour-card" popover="manual" role="dialog">. app.js: replace dialog-specific checks/showModal/close calls with :popover-open matches and showPopover()/hidePopover() calls. style.css: add .tour-card::backdrop rule to keep the backdrop transparent and non-blocking. These changes keep tour UI in the top layer and avoid modal stacking/behavior issues.