### PR TITLE
Add Linux to CI build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Tauri (Windows + macOS)
+name: Build Tauri (Windows + macOS + Linux)
 
 on:
   push:
@@ -41,6 +41,10 @@ jobs:
             runner: macos-14
             arch: x64
             target: x86_64-apple-darwin
+          - os: Linux
+            runner: ubuntu-latest
+            arch: x64
+            target: x86_64-unknown-linux-gnu
 
     steps:
       - name: Checkout
@@ -61,6 +65,12 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
       - name: Install dependencies
         run: npm ci
@@ -84,4 +94,15 @@ jobs:
         with:
           name: macos-${{ matrix.arch }}
           path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+
+      - name: Upload artifacts (Linux)
+        if: matrix.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
           if-no-files-found: error


### PR DESCRIPTION
Expand the Tauri build workflow to include Linux. Update workflow name, add a Linux matrix entry (ubuntu-latest, x86_64-unknown-linux-gnu), install required Linux packages when running on Linux (libwebkit2gtk, libayatana-appindicator3, librsvg2, patchelf), and upload Linux artifacts (AppImage, deb, rpm) conditionally. Keeps existing Windows/macOS steps intact.