### PR TITLE
Add German tutorial texts and dialog close button

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -18161,10 +18161,10 @@ function _tutRenderDialog() {
     const catLessons = TUTORIAL_DATA.lessons.filter(l => l.category === cat.id);
     if (catLessons.length === 0) return "";
     return `<div class="tutorial-category">
-      <div class="tutorial-category-label">${lang === "hu" ? cat.labelHu : (lang === "es" && cat.labelEs ? cat.labelEs : cat.labelEn)}</div>
+      <div class="tutorial-category-label">${lang === "hu" ? cat.labelHu : (lang === "es" && cat.labelEs ? cat.labelEs : (lang === "de" && cat.labelDe ? cat.labelDe : cat.labelEn))}</div>
       ${catLessons.map(lesson => {
         const done = _tutorialProgress[lesson.id]?.completed;
-        const title = lang === "hu" ? lesson.titleHu : (lang === "es" && lesson.titleEs ? lesson.titleEs : lesson.titleEn);
+        const title = lang === "hu" ? lesson.titleHu : (lang === "es" && lesson.titleEs ? lesson.titleEs : (lang === "de" && lesson.titleDe ? lesson.titleDe : lesson.titleEn));
         const stars = lesson.difficulty > 0
           ? `${lesson.difficulty}/3`
           : "TOUR";
@@ -18196,15 +18196,15 @@ function _tutShowLesson(lessonId) {
   if (!lesson || !contentEl) return;
   const canStartTour = lesson.type === "tour" || lesson.interactive === true;
 
-  const title = lang === "hu" ? lesson.titleHu : (lang === "es" && lesson.titleEs ? lesson.titleEs : lesson.titleEn);
-  const desc = lang === "hu" ? lesson.descHu : (lang === "es" && lesson.descEs ? lesson.descEs : lesson.descEn);
+  const title = lang === "hu" ? lesson.titleHu : (lang === "es" && lesson.titleEs ? lesson.titleEs : (lang === "de" && lesson.titleDe ? lesson.titleDe : lesson.titleEn));
+  const desc = lang === "hu" ? lesson.descHu : (lang === "es" && lesson.descEs ? lesson.descEs : (lang === "de" && lesson.descDe ? lesson.descDe : lesson.descEn));
   const diffStars = lesson.difficulty > 0
     ? `(${lesson.difficulty}/3)`
     : null;
   const diffLabel = lesson.difficulty === 0 ? "Tour"
-    : lesson.difficulty === 1 ? (lang === "hu" ? "Kezdo" : (lang === "es" ? "Principiante" : "Beginner"))
-    : lesson.difficulty === 2 ? (lang === "hu" ? "Kozepes" : (lang === "es" ? "Intermedio" : "Intermediate"))
-    : (lang === "hu" ? "Halado" : (lang === "es" ? "Avanzado" : "Advanced"));
+    : lesson.difficulty === 1 ? (lang === "hu" ? "Kezdo" : (lang === "es" ? "Principiante" : (lang === "de" ? "Anfänger" : "Beginner")))
+    : lesson.difficulty === 2 ? (lang === "hu" ? "Kozepes" : (lang === "es" ? "Intermedio" : (lang === "de" ? "Mittel" : "Intermediate")))
+    : (lang === "hu" ? "Halado" : (lang === "es" ? "Avanzado" : (lang === "de" ? "Fortgeschritten" : "Advanced")));
 
   const stepsHtml = lesson.steps.map((step, i) => {
     return `<div class="tutorial-step">
@@ -18241,10 +18241,10 @@ function _tutShowLesson(lessonId) {
   lesson.steps.forEach((step, i) => {
     const stepEl = contentEl.querySelectorAll(".tutorial-step")[i];
     if (!stepEl) return;
-    stepEl.querySelector(".tutorial-step-title").textContent = lang === "hu" ? step.titleHu : (lang === "es" && step.titleEs ? step.titleEs : step.titleEn);
-    stepEl.querySelector(".tutorial-step-desc").textContent = lang === "hu" ? step.descHu : (lang === "es" && step.descEs ? step.descEs : step.descEn);
+    stepEl.querySelector(".tutorial-step-title").textContent = lang === "hu" ? step.titleHu : (lang === "es" && step.titleEs ? step.titleEs : (lang === "de" && step.titleDe ? step.titleDe : step.titleEn));
+    stepEl.querySelector(".tutorial-step-desc").textContent = lang === "hu" ? step.descHu : (lang === "es" && step.descEs ? step.descEs : (lang === "de" && step.descDe ? step.descDe : step.descEn));
     const actionBtn = stepEl.querySelector(".tutorial-step-action-btn");
-    if (actionBtn) actionBtn.textContent = lang === "hu" ? step.actionLabelHu : (lang === "es" && step.actionLabelEs ? step.actionLabelEs : step.actionLabelEn);
+    if (actionBtn) actionBtn.textContent = lang === "hu" ? step.actionLabelHu : (lang === "es" && step.actionLabelEs ? step.actionLabelEs : (lang === "de" && step.actionLabelDe ? step.actionLabelDe : step.actionLabelEn));
   });
 
   contentEl.querySelectorAll(".tutorial-load-sample-btn").forEach(btn => {
@@ -18348,8 +18348,8 @@ function _tourShowStep(index) {
   const skipBtn = document.getElementById("tour-skip");
 
   if (stepLabel) stepLabel.textContent = `${index + 1} / ${_tourSteps.length}`;
-  if (cardTitle) cardTitle.textContent = lang === "hu" ? step.titleHu : (lang === "es" && step.titleEs ? step.titleEs : step.titleEn);
-  if (cardDesc) cardDesc.textContent = lang === "hu" ? step.descHu : (lang === "es" && step.descEs ? step.descEs : step.descEn);
+  if (cardTitle) cardTitle.textContent = lang === "hu" ? step.titleHu : (lang === "es" && step.titleEs ? step.titleEs : (lang === "de" && step.titleDe ? step.titleDe : step.titleEn));
+  if (cardDesc) cardDesc.textContent = lang === "hu" ? step.descHu : (lang === "es" && step.descEs ? step.descEs : (lang === "de" && step.descDe ? step.descDe : step.descEn));
   if (prevBtn) prevBtn.disabled = index === 0;
   if (nextBtn) nextBtn.textContent = index === _tourSteps.length - 1
     ? t("tourFinish") : t("tourNext");
@@ -18553,6 +18553,7 @@ function _initTutorialEvents() {
 
   tutBtn?.addEventListener("click", () => openTutorialDialog());
   tutClose?.addEventListener("click", () => tutDlg?.close());
+  document.getElementById("tutorial-dialog-close")?.addEventListener("click", () => tutDlg?.close());
 
   document.getElementById("tour-next")?.addEventListener("click", (e) => {
     e.preventDefault();

--- a/www/index.html
+++ b/www/index.html
@@ -752,9 +752,6 @@ PRINTABLE CHARACTERS
           <strong>Basic versioning &mdash; project snapshots</strong> &mdash; lightweight version control built into every project: take a named snapshot at any point, browse the timeline with notes and timestamps, restore an older state, or delete entries you no longer need. Snapshots live in sidecar JSON files next to the project on disk, so the history survives restarts and travels with the project file.
         </li>
         <li>
-          <strong>Browser run modes (VirtualC64Web)</strong> &mdash; run a PRG or D64 directly in the browser-based VirtualC64Web emulator without installing VICE. New Run menu entries: "VirtualC64" for PRG and "D64 in VirtualC64" for disk image.
-        </li>
-        <li>
           <strong>Code search</strong> &mdash; new search box on the main toolbar finds mnemonics, labels, comments, and operand text across the entire program. Jumps to matching blocks and highlights them; works in both block mode and expert mode.
         </li>
         <li>
@@ -1363,10 +1360,10 @@ PRINTABLE CHARACTERS
 
   <dialog id="tutorial-dialog" class="tutorial-dialog">
     <div class="tutorial-card">
+      <button id="tutorial-dialog-close" class="tutorial-dialog-close-btn" type="button" aria-label="Close">×</button>
       <div class="tutorial-sidebar">
         <div class="tutorial-sidebar-header">
           <h2 id="tutorial-dialog-title" class="tutorial-sidebar-title">Tutorials</h2>
-          <button id="tutorial-close" class="tutorial-close-btn" type="button" aria-label="Close">×</button>
         </div>
         <div id="tutorial-lesson-list" class="tutorial-lesson-list"></div>
       </div>

--- a/www/style.css
+++ b/www/style.css
@@ -5433,6 +5433,31 @@ body.crt-mode #crt-overlay::after {
   display: flex;
   height: min(680px, 88vh);
   overflow: hidden;
+  position: relative;
+}
+
+.tutorial-dialog-close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 5;
+  background: none;
+  border: none;
+  color: var(--secondary);
+  font-size: 1.3rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  min-height: 0;
+  height: 28px;
+  width: 28px;
+  border-radius: 0;
+  transition: background 0.12s, color 0.12s;
+}
+
+.tutorial-dialog-close-btn:hover {
+  background: rgba(0,0,0,0.08);
+  color: var(--text);
 }
 
 .tutorial-sidebar {


### PR DESCRIPTION
Add German (de) fallbacks for tutorial category/lesson/step/card text in _tutRenderDialog/_tutShowLesson/_tourShowStep and step rendering. Replace the old tutorial close control with a new #tutorial-dialog-close button in the dialog, hook it in _initTutorialEvents, and add CSS for .tutorial-dialog-close-btn (positioning and hover). Also adjust overlay positioning and remove the obsolete "Browser run modes (VirtualC64Web)" feature line from index.html.