### PR TITLE
Add test job to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run JS unit tests
+        run: npm test
+
+      - name: Run Rust integration tests
+        working-directory: src-tauri
+        run: cargo test --test exomizer_integration
+
   build:
     name: Build on ${{ matrix.os }} (${{ matrix.arch }})
+    needs: test
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/tests/delay-macro.test.js
+++ b/tests/delay-macro.test.js
@@ -1,9 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const path = require("node:path");
 const vm = require("node:vm");
 
-const appJs = fs.readFileSync("F:/Development/VisualAssembler/www/app.js", "utf8");
+const appJs = fs.readFileSync(path.join(__dirname, "..", "www", "app.js"), "utf8");
 
 function extractFunctionSource(name) {
   const marker = `function ${name}(`;

--- a/tests/macro-core.test.js
+++ b/tests/macro-core.test.js
@@ -1,9 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const path = require("node:path");
 const vm = require("node:vm");
 
-const appJs = fs.readFileSync("F:/Development/VisualAssembler/www/app.js", "utf8");
+const appJs = fs.readFileSync(path.join(__dirname, "..", "www", "app.js"), "utf8");
 
 function extractFunctionSource(name) {
   const marker = `function ${name}(`;


### PR DESCRIPTION
Add a new `test` job to the GitHub Actions build workflow that runs before the build job. The test job:

- Runs on ubuntu-latest
- Sets up Node.js 20 and Rust with caching
- Installs dependencies
- Runs JS unit tests via `npm test`
- Runs Rust integration tests for exomizer

The build job now depends on test completion via `needs: test`.