### PR TITLE
Fix borrow checker issues in file dialog functions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -358,7 +358,7 @@ async fn choose_vice_executable(app: AppHandle) -> serde_json::Value {
     let dialog = app.dialog().clone();
     let mut file_dialog = dialog.file();
 
-    if let Some(folder) = working_folder {
+    if let Some(folder) = working_folder.as_ref() {
         file_dialog = file_dialog.set_directory(folder);
     }
 
@@ -412,7 +412,7 @@ async fn choose_exomizer_executable(app: AppHandle) -> serde_json::Value {
     let dialog = app.dialog().clone();
     let mut file_dialog = dialog.file();
 
-    if let Some(folder) = working_folder {
+    if let Some(folder) = working_folder.as_ref() {
         file_dialog = file_dialog.set_directory(folder);
     }
 


### PR DESCRIPTION
Use `.as_ref()` when pattern matching on `working_folder` in `choose_vice_executable` and `choose_exomizer_executable` to borrow the value instead of taking ownership. This allows the variable to be reused if needed and avoids unnecessary moves.