### PR TITLE
Include parseMacroCountOrSize in macro tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -97,7 +97,8 @@
       "Bash(grep -n \"\\\\\\\\.text\\\\|isTextMacro\" F:/Development/VisualAssembler/www/app.js)",
       "Bash(awk 'NR>=1{print}')",
       "Bash(grep -A1 \"expandedProgram.push\\({ ...block, _isMacroInvokeHeader\")",
-      "Bash(grep -n 'return { ok: false, error: \"\\\\|return { ok: false, error: `' F:/Development/VisualAssembler/www/app.js)"
+      "Bash(grep -n 'return { ok: false, error: \"\\\\|return { ok: false, error: `' F:/Development/VisualAssembler/www/app.js)",
+      "Bash(npm test *)"
     ],
     "additionalDirectories": [
       "/Users/ztarczali/dev/VisualAssembler/www"

--- a/tests/macro-core.test.js
+++ b/tests/macro-core.test.js
@@ -54,6 +54,7 @@ function createMacroContext(extraContext = {}) {
       "resolveProgramNumericValue",
       "parseDelayFrameCount",
       "parseMacroAddress",
+      "parseMacroCountOrSize",
       "resolveProgramConstValue",
       "addLayoutLabels",
       "buildOperandPreview",


### PR DESCRIPTION
Expose parseMacroCountOrSize in the macro test context so unit tests can call it (tests/macro-core.test.js). Also add a quick "npm test *" entry to .claude/settings.local.json to allow running tests from the helper commands. Files changed: tests/macro-core.test.js, .claude/settings.local.json.